### PR TITLE
Remove use of percent unit

### DIFF
--- a/gui/app.py
+++ b/gui/app.py
@@ -56,15 +56,15 @@ material_list = []
 energy = u.Quantity(np.arange(DEFAULT_ENERGY_LOW, DEFAULT_ENERGY_HIGH, 1), "keV")
 
 this_material = Material(DEFAULT_MATERIAL[0], DEFAULT_THICKNESS[0])
-y = this_material.transmission(energy).value / 100.0
+y = this_material.transmission(energy)
 air_density = get_air_density(DEFAULT_AIR_PRESSURE, DEFAULT_AIR_TEMPERATURE)
 air = Material('air', DEFAULT_AIR_THICKNESS, density=air_density)
-y *= air.transmission(energy).value / 100.0
+y *= air.transmission(energy)
 this_detector = Material(DEFAULT_DETECTOR_MATERIAL, DEFAULT_DETECTOR_THICKNESS)
-y *= this_detector.absorption(energy).value / 100.0
+y *= this_detector.absorption(energy)
 
 x = energy.value
-source = ColumnDataSource(data={"x": x, "y": y * 100})
+source = ColumnDataSource(data={"x": x, "y": y})
 
 all_materials = list(roentgen.elements["symbol"]) + \
                 list(roentgen.compounds["symbol"])
@@ -78,9 +78,9 @@ plot = figure(
     title=DEFAULT_TYPE,
     tools=TOOLS,
     x_range=[DEFAULT_ENERGY_LOW, DEFAULT_ENERGY_HIGH],
-    y_range=[0, 100],
+    y_range=[0, 1],
 )
-plot.yaxis.axis_label = "%"
+plot.yaxis.axis_label = "fraction"
 plot.xaxis.axis_label = "Energy [keV]"
 plot.line("x", "y", source=source, line_width=3, line_alpha=0.6)
 
@@ -96,12 +96,12 @@ energy_step = Slider(title="energy steps", value=1, start=0.1, end=2, step=0.1)
 
 # materials in the path
 material_input = TextInput(title="Material", value=DEFAULT_MATERIAL[0])
-thickness_input = TextInput(title="thickness", value=f"{DEFAULT_THICKNESS[0]}")
-density_input = TextInput(title="density", value=f"{this_material.density}")
+thickness_input = TextInput(title="thickness", value=str(DEFAULT_THICKNESS[0]))
+density_input = TextInput(title="density", value=str(this_material.density))
 
-air_thickness_input = TextInput(title="air path length", value=f"{DEFAULT_AIR_THICKNESS}")
-air_pressure_input = TextInput(title='air pressure', value=f"{DEFAULT_AIR_PRESSURE}")
-air_temperature_input = TextInput(title='air temperature', value=f"{DEFAULT_AIR_TEMPERATURE}")
+air_thickness_input = TextInput(title="air path length", value=str(DEFAULT_AIR_THICKNESS))
+air_pressure_input = TextInput(title='air pressure', value=str(DEFAULT_AIR_PRESSURE))
+air_temperature_input = TextInput(title='air temperature', value=str(DEFAULT_AIR_TEMPERATURE))
 
 detector_material_input = TextInput(title='Detector', value=DEFAULT_DETECTOR_MATERIAL)
 detector_thickness_input = TextInput(title='thickness', value=str(DEFAULT_DETECTOR_THICKNESS))
@@ -139,9 +139,9 @@ def update_data(attrname, old, new):
                                  u.Quantity(thickness_input.value).to("micron"),
                                  density=u.Quantity(density_input.value).to("g / cm ** 3"))
         if i == 0:
-            y = this_material.transmission(energy).value / 100.0
+            y = this_material.transmission(energy)
         else:
-            y *= this_material.transmission(energy).value / 100.0
+            y *= this_material.transmission(energy)
         i += 0
         plot_title += f"{this_material.name} {this_material.thickness}"
 
@@ -154,15 +154,15 @@ def update_data(attrname, old, new):
                                   u.Quantity(air_temperature_input.value))
     air = Material('air', u.Quantity(air_thickness_input.value).to("meter"),
                    density=air_density)
-    y *= air.transmission(energy).value / 100.0
+    y *= air.transmission(energy)
     plot_title += f" {air.name} {air.density.to('g / cm**3'):.2E} {air.thickness:.2f}"
 
     this_detector = Material(detector_material_input.value, u.Quantity(detector_thickness_input.value),
                              density=u.Quantity(detector_density_input.value))
-    y *= this_detector.absorption(energy).value / 100.0
+    y *= this_detector.absorption(energy)
     plot_title += f" {this_detector.name} {this_detector.thickness:.2f}"
     plot.title.text = plot_title
-    source.data = dict(x=x, y=y * 100)
+    source.data = dict(x=x, y=y)
 
 
 def update_detector_density_and_data(attrname, old, new):

--- a/roentgen/absorption/material.py
+++ b/roentgen/absorption/material.py
@@ -85,10 +85,8 @@ class Material(object):
             An array of energies in keV
         """
         coefficients = self.mass_attenuation_coefficient.func(energy)
-        transmission = (
-            np.exp(-coefficients * self.density * self.thickness)
-        )
-        return transmission
+        transmission = np.exp(-coefficients * self.density * self.thickness)
+        return transmission.value  # remove the dimensionless unit
 
     @u.quantity_input(energy=u.keV)
     def absorption(self, energy):
@@ -140,7 +138,7 @@ class Compound(object):
         return txt + ">"
 
     def transmission(self, energy):
-        """Provide the transmission fraction.
+        """Provide the transmission fraction (0 to 1).
 
         Parameters
         ----------
@@ -212,7 +210,7 @@ class MassAttenuationCoefficient(object):
     def get_filename(material_str):
         if len(material_str) <= 2:
             # likely a symbol of an element
-            if material_str in list(elements["symbol"]):
+            if material_str in list(roentgen.elements["symbol"]):
                 return
 
 

--- a/roentgen/absorption/material.py
+++ b/roentgen/absorption/material.py
@@ -86,7 +86,7 @@ class Material(object):
         """
         coefficients = self.mass_attenuation_coefficient.func(energy)
         transmission = (
-            np.exp(-coefficients * self.density * self.thickness) * 100 * u.percent
+            np.exp(-coefficients * self.density * self.thickness)
         )
         return transmission
 
@@ -99,7 +99,7 @@ class Material(object):
         energy : `astropy.units.Quantity`
             An array of energies in keV.
         """
-        return 100 * u.percent - self.transmission(energy)
+        return 1.0 - self.transmission(energy)
 
 
 class Compound(object):
@@ -150,10 +150,10 @@ class Compound(object):
         transmission = np.ones(len(energy), dtype=np.float)
         for material in self.materials:
             this_transmission = (
-                material.transmission(energy).to("percent").value / 100.0
+                material.transmission(energy)
             )
             transmission *= this_transmission
-        return transmission * 100 * u.percent
+        return transmission
 
     def absorption(self, energy):
         """Provides the absorption fraction (0 to 1).
@@ -163,7 +163,7 @@ class Compound(object):
         energy : `astropy.units.Quantity`
             An array of energies in keV.
         """
-        return 100 * u.percent - self.transmission(energy)
+        return 1.0 - self.transmission(energy)
 
 
 class MassAttenuationCoefficient(object):

--- a/roentgen/conftest.py
+++ b/roentgen/conftest.py
@@ -2,7 +2,6 @@
 # by importing them here in conftest.py they are discoverable by py.test
 # no matter how it is invoked within the source tree.
 
-from astropy.tests.pytest_plugins import *
 
 ## Uncomment the following line to treat all DeprecationWarnings as
 ## exceptions

--- a/roentgen/tests/test_material.py
+++ b/roentgen/tests/test_material.py
@@ -8,6 +8,7 @@ import astropy.units as u
 all_materials = list(roentgen.elements['symbol']) + list(roentgen.compounds['symbol'])
 energy_array = u.Quantity(np.arange(1, 100, 1), 'keV')
 
+
 @pytest.fixture(params=all_materials)
 def mass_atten(request):
     return MassAttenuationCoefficient(request.param)
@@ -86,11 +87,9 @@ def test_threematerials_to_compound(material):
                       Material('Ge', 500 * u.micron) +
                       Material('cdte', 100 * u.micron), Compound)
 
+
 def test_compound_calculations(material):
     comp = Material('Ge', 500 * u.micron) + Material('cdte', 100 * u.micron)
-    # test that it returns a quantity
-    assert isinstance(comp.absorption(energy_array), u.Quantity)
-    assert isinstance(comp.transmission(energy_array), u.Quantity)
     # test that it returns the same number of elements as energy array
     assert len(comp.absorption(energy_array)) == len(energy_array)
     assert len(comp.transmission(energy_array)) == len(energy_array)
@@ -103,7 +102,7 @@ def thick_material(request):
 
 def test_opaque(thick_material):
     # check that extremely large amounts of material mean no transmission
-    assert thick_material.transmission(1 * u.keV) / (100 * u.percent) < 1e-6
+    assert thick_material.transmission(1 * u.keV) < 1e-6
 
 
 @pytest.fixture(params=all_materials)
@@ -113,4 +112,4 @@ def thin_material(request):
 
 def test_transparent(thin_material):
     # check that extremely large amounts of material mean no transmission
-    assert thin_material.transmission(1 * u.keV) > 90 * u.percent
+    assert thin_material.transmission(1 * u.keV) > 0.90

--- a/setup.cfg
+++ b/setup.cfg
@@ -12,10 +12,13 @@ all_files = 1
 upload-dir = docs/_build/html
 show-response = 1
 
-[pytest]
-minversion = 2.2
-norecursedirs = build docs/_build
+[tool:pytest]
+minversion = 3.0
+testpaths = "roentgen" "docs"
+norecursedirs = ".tox" "build" "docs[\/]_build" "docs[\/]generated" "*.egg-info" "astropy_helpers" "examples"
 doctest_plus = enabled
+doctest_optionflags = NORMALIZE_WHITESPACE FLOAT_CMP ELLIPSIS
+addopts = --doctest-rst -p no:warnings
 
 [ah_bootstrap]
 auto_use = True


### PR DESCRIPTION
Removing the use of percent unit on absorption and transmission as it provides little to no value and makes it more difficult to use.